### PR TITLE
matrix_distance_squared_jac off by a factor

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -60,7 +60,7 @@ pub fn matrix_distance_squared_jac(
         .collect();
     let jacs = jus
         .iter()
-        .map(|jusi| -(jusi.re * s.re + jusi.im * s.im) * size as f64 / s.norm())
+        .map(|jusi| -(jusi.re * s.re + jusi.im * s.im) / (size as f64 * s.norm()))
         .collect();
     (dsq, jacs)
 }


### PR DESCRIPTION
It has recently come to my attention that the matrix_distanced_squared_jac implementation in https://github.com/BQSKit/qsearch is off by a factor, and bqskitrs uses the same implementation.  This improvement may lead to faster runtime in numerical optimizers that use matrix_distance_squared_jac, such as BFGS.